### PR TITLE
Dont make pundit check for my_index. More rigorous delete policy.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,20 +6,21 @@ class ApplicationController < ActionController::Base
     include Pundit
 
      # Pundit: white-list approach.
-      after_action :verify_authorized, except: :index, unless: :skip_pundit?
+      after_action :verify_authorized, except: %i[index my_index], unless: :skip_pundit?
       # after_action :verify_policy_scoped, only: :index, unless: :skip_pundit?
-       # Uncomment when you *really understand* Pundit!
-        # rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
-        # def user_not_authorized
-        #   flash[:alert] = "You are not authorized to perform this action."
-        #   redirect_to(root_path)
-        # end
 
-    
+     # Uncomment when you *really understand* Pundit!
+      # rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+      # def user_not_authorized
+      #   flash[:alert] = "You are not authorized to perform this action."
+      #   redirect_to(root_path)
+      # end
+
+
     def configure_permitted_parameters
       # For additional fields in app/views/devise/registrations/new.html.erb
       devise_parameter_sanitizer.permit(:sign_up, keys: [:first_name, :last_name, :document, :address, :phone])
-  
+
       # For additional in app/views/devise/registrations/edit.html.erb
       # devise_parameter_sanitizer.permit(:account_update, keys: [:username])
     end
@@ -37,4 +38,4 @@ end
 
 
 
- 
+

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -49,8 +49,7 @@ class ProductsController < ApplicationController
   end
 
   def my_index
-    @products = Product.where(company: current_user.company)#.order(price: :asc)
-    authorize @products
+    @products = Product.where(company: current_user.company)
   end
 
   private

--- a/app/policies/product_policy.rb
+++ b/app/policies/product_policy.rb
@@ -13,27 +13,21 @@ class ProductPolicy < ApplicationPolicy
     true
   end
 
-    def edit?
-      record.company.user == user
-    # - record: the restaurant passed to the `authorize` method in controller
-    # - user:   the `current_user` signed in with Devise.
-    end
+  def edit?
+    record.company.user == user
+  # - record: the restaurant passed to the `authorize` method in controller
+  # - user:   the `current_user` signed in with Devise.
+  end
 
-    def update?
-      edit?
-      # - record: the restaurant passed to the `authorize` method in controller
-    # - user:   the `current_user` signed in with Devise.
-    end
+  def update?
+    edit?
+  end
 
-    def destroy?
-      true
-    end
+  def destroy?
+    edit?
+  end
 
-    def my_index?
-      true
-    end
-
-    def show?
-      true
-    end
+  def show?
+    true
+  end
 end


### PR DESCRIPTION
We skip pundit authorization to my_index with `after_action :verify_authorized, except: %i[index my_index], unless: :skip_pundit?`. We also check if the product user is the current logged user before executing the delete action.

The rest of the changes are cosmetic (fixed indentation and redundant comments)